### PR TITLE
Add openapi spec file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,14 @@
+.PHONY: install
+install:
+	go install github.com/deepmap/oapi-codegen/cmd/oapi-codegen@latest
+
+.PHONY: generate
+generate: install
+	mkdir -p api
+	oapi-codegen -generate types -o ./api/types.gen.go -package api openapi.yml
+	oapi-codegen -generate client -o ./api/client.gen.go -package api openapi.yml
+	oapi-codegen -generate gorilla -o ./api/server.gen.go -package api openapi.yml
+
+.PHONY: opengenerate
+opengenerate:
+	openapi-generator generate -i openapi.yml -g go --type-mappings=string+application\/json=json.RawMessage

--- a/openapi.yml
+++ b/openapi.yml
@@ -1,0 +1,892 @@
+openapi: 3.0.0
+info:
+  title: fleet-server API
+  version: 0.0.1
+  license:
+    name: Elastic License 2.0
+    url: https://www.elastic.co/licensing/elastic-license
+  description: |
+    The fleet-server API that is used by agents when enrolled with fleet.
+
+    Note that the current implementations in the fleet-server and elastic-agent may have some difference specifically when it comes to some objects.
+    This is most notable when comparing the `Action` implementations. Fleet-server uses a general template for all actions and the elastic-agent will have more specific representations.
+
+    The implementation of fleet-server by default also includes a connection count limiter, as well as limiters for request body sizes.
+    If an agent attempts to make request but there are no remaining connections, the attempt will be blocked and the agent will get an error.
+    If an agent tries to send a body that is too large the fleet-server will respond with a 400 status code.
+components:
+  securitySchemes:
+    apiKey:
+      description: API key security will check that the API key exists and is enabled, but will not check additional permissions
+      type: apiKey
+      in: header
+      name: ApiKey
+    agentApiKey:
+      description: Agent API key security will check that the API key exists, is enabled, and is assigned to the agent
+      type: apiKey
+      in: header
+      name: ApiKey
+  schemas:
+    error:
+      description: Error processing request.
+      type: object
+      required:
+        - statusCode
+        - error
+      properties:
+        statusCode:
+          type: integer
+          description: The HTTP status code of the error.
+        error:
+          type: string
+          description: Error type.
+        message:
+          type: string
+          description: (optional) Error message.
+    statusResponseVersion:
+      description: Version information included in the response to an authorized status request.
+      type: object
+      properties:
+        number:
+          type: string
+          description: The fleet-server version.
+        build_hash:
+          type: string
+          description: The commit that the fleet-server was built from.
+        build_time:
+          type: string
+          description: The date-time that the fleet-server binary was created.
+          #format: date-time # not using date-time format at the moment because the currently available objects have plain strings
+    statusResponse:
+      description: Status response information.
+      type: object
+      required:
+        - name
+        - status
+      properties:
+        name:
+          type: string
+          description: Service name.
+        status:
+          type: string
+          description: |
+            A Unit state that fleet-server may report.
+            Unit state is defined in the elastic-agent-client specification.
+          enum:
+            - starting
+            - configuring
+            - healthy
+            - degraded
+            - failed
+            - stopping
+            - stopped
+            - unknown
+        version:
+          $ref: '#/components/schemas/statusResponseVersion'
+    enrollMetadata:
+      description: Metadata associated with the agent that is enrolling to fleet.
+      type: object
+      required:
+        - user_provided
+        - local
+        - tags
+      properties:
+        user_provided: # FIXME should we deprecate this attribute?
+          description: |
+            An embedded JSON object that holds user-provided meta-data values.
+            Defined in fleet-server as a `json.RawMessage`.
+            fleet-server does not use these values on enrollment of an agent.
+            Defined in the elastic-agent as a `map[string]interface{}` with no way to specify any values.
+          type: string
+          format: application/json
+          x-go-type: json.RawMessage
+        local:
+          description: |
+            An embedded JSON object that holds meta-data values.
+            Defined in fleet-server as a `json.RawMessage`, defined as an object in the elastic-agent.
+            elastic-agent will populate the object with information from the binary and host/system environment.
+            If not empty fleet-server will update the value of `local["elastic"]["agent"]["id"]` to the agent ID (assuming the keys exist).
+            The (possibly updated) value is sent by fleet-server when creating the record for a new agent.
+          type: string
+          format: application/json
+          x-go-type: json.RawMessage
+        tags:
+          description: |
+            User provided tags for the agent.
+            fleet-server will pass the tags to the agent record on enrollment.
+          type: array
+          items:
+            type: string
+    enrollRequest:
+      description: A request to enroll a new agent into fleet.
+      type: object
+      required:
+        - type
+        - shared_id
+        - metadata
+      properties:
+        type:
+          description: |
+            The enrollment type of the agent.
+            The agent only supports the PERMANENT value
+          type: string
+          enum: # FIXME what are the others for? Should this attribute be deprecated?
+            - EPHEMERAL
+            - PERMANENT
+            - TEMPORARY
+        shared_id: # FIXME Should this attribute be deprecated?
+          type: string
+          description: |
+            The shared ID of the agent.
+            To support pre-existing installs.
+            NOT YET IMPLEMENTED.
+        metadata:
+          $ref: '#/components/schemas/enrollMetadata'
+    enrollResponseItem:
+      description: Response to a successful enrollment of an agent into fleet.
+      type: object
+      required:
+        - id
+        - active
+        - policy_id
+        - type
+        - enrolled_at
+        - user_provided_metadata
+        - local_metadata
+        - actions
+        - access_api_key_id
+        - access_api_key
+        - status
+        - tags
+      properties:
+        id:
+          description: The agent ID
+          type: string
+        active: # FIXME We don't support enrolling in the inactive state, i don't know if that's on the roadmap. Is this attribute needed?
+          description: If the agent is active in fleet. Will be set to true upon enrollment.
+          type: boolean
+        policy_id:
+          description: The policy ID that the agent is enrolled with. Decoded from the API key used in the request.
+          type: string
+        type: # FIXME is this needed?
+          description: The enrollment request type.
+          type: string
+        enrolled_at:
+          description: The RFC3339 timestamp that the agent was enrolled at.
+          type: string
+          #format: date-time
+        user_provided_metadata: # FIXME still needed?
+          description: A copy of the user provided metadata from the enrollment request. Currently will be empty.
+          type: string
+          format: application/json
+          x-go-type: json.RawMessage
+        local_metadata:
+          description: A copy of the (updated) local metadata provided in the enrollment request.
+          type: string
+          format: application/json
+          x-go-type: json.RawMessage
+        actions: # FIXME deprecate?
+          description: Defined in fleet-server and elastic-agent as `[]interface{}` but never used.
+          type: array
+          items:
+            type: object
+        access_api_key_id:
+          description: The id of the ApiKey that fleet-server has generated for the enrolling agent.
+          type: string
+        access_api_key:
+          description: The ApiKey token that fleet-server has generated for the enrolling agent.
+          type: string
+          format: password
+        status: # FIXME Does this have any value? The UI does other calculations to infer status.
+          description: Agent status from fleet-server. fleet-ui may differ.
+          type: string
+        tags:
+          description: A copy of the tags that were sent with the enrollment request.
+          type: array
+          items:
+            type: string
+    enrollResponse:
+      description: The enrollment action response.
+      type: object
+      required:
+        - action
+        - item
+      properties:
+        action:
+          description: The action result. Will have the value "created".
+          type: string
+        item:
+          $ref: '#/components/schemas/enrollResponseItem'
+    checkinRequest:
+      type: object
+      required:
+        - status
+        - message
+      properties:
+        status:
+          description: The agent state, inferred from agent control protocol states.
+          type: string
+          enum:
+            - online
+            - error
+            - degraded
+        message:
+          description: State message, may be overridden or use the error message of a failing component.
+          type: string
+        ack_token:
+          description: |
+            The ack_token form a previous response if the agent has checked in before.
+            Translated to a sequence number in fleet-server in order to retrieve any new actions for the agent from the last checkin.
+          type: string
+        local_metadata:
+          description: |
+            An embedded JSON object that holds meta-data values.
+            Defined in fleet-server as a `json.RawMessage`, defined as an object in the elastic-agent.
+            elastic-agent will populate the object with information from the binary and host/system environment.
+            fleet-server will update the agent record if a checkin response contains different data from the record.
+          type: string
+          format: application/json
+          x-go-type: json.RawMessage
+        components:
+          description: |
+            An embedded JSON object that holds component information that the agent is running.
+            Defined in fleet-server as a `json.RawMessage`, defined as an object in the elastic-agent.
+            fleet-server will update the components in an agent record if they differ from this object.
+          type: string
+          format: application/json
+          x-go-type: json.RawMessage
+    action:
+      description: |
+        An action for an elastic-agent.
+        The actions are defined in generic terms on the fleet-server.
+        The elastic-agent will have additional details for what is expected when a specific action-type is recieved.
+        The structure of the `data` attribute will vary between action types.
+
+        An additional consideration is Scheduled Actions. Scheduled actions are currently defined as actions that have non-empty values for both the `start_time` and `expiration` attributes.
+      type: object
+      required:
+        - agent_id
+        - created_at
+        - data
+        - id
+        - type
+        - input_type
+      properties:
+        agent_id:
+          description: The agent ID.
+          type: string
+        created_at:
+          description: Time when the action was created.
+          type: string
+          #format: date-time
+        start_time:
+          description: The earliest execution time for the action. Agent will not execute the action before this time. Used for scheduled actions.
+          type: string
+          #format: date-time
+        expiration:
+          description: The latest start time for the action. Actions will be dropped by the agent if execution has not started by this time. Used for scheduled actions.
+          type: string
+          #format: date-time
+        data:
+          description: An embedded action-specific object.
+          type: object
+        id:
+          description: The action ID.
+          type: string
+        type:
+          description: The action type.
+          type: string
+        input_type: # NOTE not sure why input_type and timeout are not part of data; do we have an explanation?
+          description: The input type of the action for actions with type `INPUT_ACTION`.
+          type: string
+        timeout:
+          description: The timeout value (in seconds) for actions with type `INPUT_ACTION`.
+          type: integer
+          format: int64
+    checkinResponse:
+      type: object
+      required:
+        - action
+      properties:
+        ack_token:
+          description: The acknowlegment token used to indicate action delivery.
+          type: string
+        action:
+          description: The action result. Set to "checkin".
+          type: string
+        actions:
+          description: A list of actions that the agent must execute.
+          type: array
+          items:
+            $ref: '#/components/schemas/action'
+    event:
+      description: The ack for a specific action that the elastic-agent has executed.
+      type: object
+      required:
+        - type
+        - subtype
+        - agent_id
+        - action_id
+        - action_input_type
+        - policy_id
+        - stream_id
+        - timestamp
+        - message
+        - started_at
+        - completed_at
+      properties:
+        type: # FIXME: Deprecate?
+          description: The event type of the ack. Not used by fleet-server. Currently the elastic-agent will only generate ACTION_RESULT events.
+          type: string
+          enum:
+            - STATE
+            - ERROR
+            - ACTION_RESULT
+            - ACTION
+        subtype: # FIXME: Deprecate?
+          description: The subtype of the ack event. Not used by fleet-server. Currently the elastic-agent will only generate ACKNOWLEDGED events.
+          type: string
+          enum:
+            - RUNNING
+            - STARTING
+            - IN_PROGRESS
+            - CONFIG
+            - FAILED
+            - STOPPING
+            - STOPPED
+            - DATA_DUMP
+            - ACKNOWLEDGED
+            - UNKNOWN
+        agent_id:
+          description: The ID of the agent that executed the action.
+          type: string
+        action_id:
+          description: The action ID.
+          type: string
+        action_input_type: # FIXME fleet-server will list this in ES, but I'm not sure if it's needed.
+          description: The input_type of the action for input actions.
+          type: string
+        policy_id: # FIXME: Deprecate?
+          description: Not used by the fleet-server.
+          type: string
+        stream_id: # FIXME Deprecate?
+          description: Not used by the fleet-server.
+          type: string
+        timestamp:
+          description: The timestamp of the acknowledgement event. Has the format of "2006-01-02T15:04:05.99999-07:00"
+          type: string
+          #format: date-time
+        message:
+          description: An acknowlegement message. The elastic-agent inserts the action ID and action type into this message.
+          type: string
+        payload:
+          description: |
+            An embedded JSON object that contains additional information for the fleet-server to process.
+            Defined as a json.RawMessage in both the fleet-server and the elastic-agent.
+
+            Is currently used by UPGRADE actions to signal retries.
+            If the error attribute is non empty payload is checked for `retry: bool` and `retry_attempt: int`.
+            If retry is true, fleet-serve will mark the agent as retrying, if it's false the upgrade will be marked as failed.
+          type: string
+          format: application/json
+          x-go-type: json.RawMessage
+        started_at:
+          description: The time at which the action was started. Used only when acknowledging input actions.
+          type: string
+          #format: date-time
+        completed_at:
+          description: The time at which the action was completed. Used only when acknowledging input actions
+          type: string
+          #format: date-time
+        action_data:
+          description: The action data for the input action being acknowledged.
+          type: string
+          format: application/json
+          x-go-type: json.RawMessage
+        action_response:
+          description: The action response for the input action being acknowledged.
+          type: string
+          format: application/json
+          x-go-type: json.RawMessage
+        error:
+          description: |
+            An error message.
+            If this is non-empty an error has occured when executing the action.
+            For some actions (such as UPGRADE actions) it may result in the action being marked as failed.
+          type: string
+    ackRequest:
+      description: The request an elastic-agent sends to fleet-serve to acknowledge the execution of one or more actions.
+      type: object
+      required:
+        - events
+      properties:
+        events:
+          type: array
+          items:
+            $ref: '#/components/schemas/event'
+    ackResponseItem:
+      description: The results of processing an acknowledgement event.
+      type: object
+      required:
+        - status
+      properties:
+        status:
+          description: An HTTP status code that indicates if the event was processed successfully or not.
+          type: integer
+        message:
+          description: HTTP status text.
+          type: string
+    ackResponse:
+      description: Response to processing acknowledgement events.
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          description: The action result. Will have the value "acks".
+          type: string
+        errors:
+          description: A flag to indicate if one or more errors occured when proccessing events.
+          type: boolean
+        items:
+          description: The in-order list of results from processing events.
+          type: array
+          items:
+            $ref: '#/components/schemas/ackResponseItem'
+  parameters:
+    requestId:
+      name: X-Request-ID
+      description: The request tracking ID for APM.
+      in: header
+      schema:
+        type: string
+    userAgent:
+      name: User-Agent
+      description: |
+        The user-agent header that is sent.
+        Must have the format "elastic agent X.Y.Z" where "X.Y.Z" indicates the agent version.
+        The agent version must not be greater than the version of the fleet-server.
+      in: header
+      required: true
+      schema:
+        type: string
+      examples:
+        valid:
+          description: A valid User-Agent header from the elastic-agent.
+          value: elastic agent 8.6.0
+        validWithSuffix:
+          description: A version number may include an optional suffix
+          value: elastic agent 8.6.0-SNAPSHOT
+        invalidName:
+          description: The elastic-agent name is not formatted correctly.
+          value: elastic-agent 8.6.0
+        outdatedVersion:
+          description: The version string given is too old.
+          value: elastic agent 7.0.0
+  responses:
+    badRequest:
+      description: |
+        A 400 response for receiving an invalid User-Agent header or version number (checkin and enroll endpoints).
+        Or any other undefined error encounted by the fleet-server. May be returned by any endpoint except /api/fleet/status.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/error'
+          examples:
+            badRequest:
+              description: Generic bad request response.
+              value:
+                statusCode: 400
+                error: BadRequest
+    keyNotEnabled:
+      description: 401 response when the API key is not enabled on any endpoint except /api/fleet/status. Or when there are issues updating an inactive agent on the ack endpoint.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/error'
+          examples:
+            unauthorized:
+              description: The ApiKey is not enabled
+              value:
+                statusCode: 401
+                error: Unauthorized
+                message: ApiKey not enabled
+    agentNotFound:
+      description: 404 response when the agent is not found. May be returned by checkin endpoint. or endpoints that use the agentApiKey auth scheme
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/error'
+          examples:
+            agentNotFound:
+              description: The agent is not found.
+              value:
+                statusCode: 404
+                error: AgentNotFound
+                message: agent could not be found
+    deadline:
+      description: 408 request timeout.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/error'
+          examples:
+            requestTimeout:
+              description: Deadline exceeded.
+              value:
+                statusCode: 408
+                error: RequestTimeout
+                message: timeout on request
+    throttle:
+      description: 428 rate limiting request. Only returned by artifacts endpoint.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/error'
+          examples:
+            rateLimit:
+              description: Too many requests - rate limit reached.
+              value:
+                statusCode: 428
+                error: TooManyRequests
+                message: too many requests
+    unavailable:
+      description: |
+        503 response when the server is not available for some reason.
+        Such as if a context is cancelled or the connection (to ES) is refused.
+        May be returned by any endpoint.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/error'
+          examples:
+            unavailable:
+              description: Service unavailable
+              value:
+                statusCode: 503
+                error: ServiceUnavailable
+                message: Fleet server unable to communicate with Elasticsearch
+
+paths:
+  /api/status:
+    get:
+      parameters:
+        - $ref: '#/components/parameters/requestId'
+      security:
+        - {}
+        - apiKey: []
+      description: |
+        Return the fleet-server status.
+        The status code will either be 200 if healthy, or 503 if not.
+        Authentication for this endpoint is optional, if not provided a shorter response body is returned.
+      responses:
+        '200':
+          description: Healthy fleet-server response.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/statusResponse'
+              examples:
+                unauthenticated:
+                  description: The short response for unauthenticated requests.
+                  value:
+                    name: fleet-server
+                    status: healthy
+                authenticated:
+                  description: The full response for an authenticated request.
+                  value:
+                    name: fleet-server
+                    status: healthy
+                    version:
+                      number: 8.6.0
+                      build_hash: fd6d862bcbebe841f930e8cdd2fa5107922e66e7
+                      build_time: 2022-12-01T01:02:03Z
+
+        '503':
+          description: Unhealthy fleet-server response.
+          content:
+            text/plain: {}
+            application/json:
+              schema:
+                $ref: '#/components/schemas/statusResponse'
+              examples:
+                unauthenticated:
+                  description: The short response for unauthenticated requests.
+                  value:
+                    name: fleet-server
+                    status: failed
+                authenticated:
+                  description: The full response for an authenticated request.
+                  value:
+                    name: fleet-server
+                    status: failed
+                    version:
+                      number: 8.6.0
+                      build_hash: fd6d862bcbebe841f930e8cdd2fa5107922e66e7
+                      build_time: 2022-12-01T01:02:03Z
+  /api/fleet/agents/{id}:
+    # FIXME: The fleet-server route has the enroll endpoint created with an id parameter.
+    # However the id is expected to be "enroll" by fleet-server's implementation.
+    # Should this route be changed to reflect that?
+    post:
+      parameters:
+        - name: id
+          in: path
+          description: The id of the enrollment action. Expected to be "enroll".
+          required: true
+          schema:
+            type: string
+          examples:
+            enroll:
+              description: The only accepted value
+              value: enroll
+        - $ref: '#/components/parameters/userAgent'
+        - $ref: '#/components/parameters/requestId'
+      security:
+        - apiKey: []
+      description: Enroll a new agent to fleet-server. The agent is enrolled in the policy encoded in the apiKey used.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/enrollRequest'
+            examples:
+              request:
+                description: A request to enroll a new agent.
+                value:
+                  type: PERMANENT
+                  metadata:
+                    local:
+                      elastic:
+                        agent:
+                          id: ""
+                          version: 8.6.0
+                          snapshot: false
+                      host:
+                        hostname: test
+                    tags:
+                      - us-west
+                      - test
+      responses:
+        '200':
+          description: Agent enrolled successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/enrollResponse'
+              examples:
+                success:
+                  description: Agent enrolled successfully.
+                  value:
+                    action: created
+                    item:
+                      id: agent-test-id
+                      active: true
+                      policy_id: agent-policy-id
+                      type: PERMANENT
+                      enrolled_at: 2022-12-01T01:02:03Z
+                      user_provided_metadata: {}
+                      local_metadata:
+                        elastic:
+                          agent:
+                            id: agent-test-id
+                            version: 8.6.0
+                            snapshot: false
+                        host:
+                          hostname: test
+                      access_api_key_id: api-key-id
+                      access_api_key: api-key-token
+                      status: online
+                      tags:
+                        - us-west
+                        - test
+        '400':
+          $ref: '#/components/responses/badRequest'
+        '401':
+          $ref: '#/components/responses/keyNotEnabled'
+        '404':
+          description: Bad request path, expected id to be enroll.
+        '408':
+          $ref: '#/components/responses/deadline'
+        '503':
+          $ref: '#/components/responses/unavailable'
+  /api/fleet/agents/{id}/checkin:
+    post:
+      description: |
+        The agent checkin endpoint.
+        Clients will long-poll this endpoint.
+        The fleet-server will return a response if there is a new action for the agent, or if the polling timeout is reached.
+        The fleet-server may also use some jitter to offset the polling duration, if a jitter value is defined the timeout value is the duration's max possible value.
+        The fleet-sever polling timeout is short-circuited in cases of heavy load where setting up the checkin (ensuring the API key is authed etc) takes longer then the timeout value.
+        The fleet-server sets the timeout to 5m.
+        The client sets its connection timeout to 10m. # FIXME: verify timeout
+        The cloud fleet-proxy timeout is set to 5m20s. # FIXME: verify timeout
+      parameters:
+        - name: id
+          in: path
+          description: The agent ID.
+          required: true
+          schema:
+            type: string
+        - name: Accept-Encoding
+          in: header
+          description: |
+            If the agent is able to accept encoded responses.
+            Used to indicate if GZIP compression may be used by the server.
+            The elastic-agent does not use the accept-encoding header.
+          schema:
+            type: string
+        - $ref: '#/components/parameters/userAgent'
+        - $ref: '#/components/parameters/requestId'
+      security:
+        - agentApiKey: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/checkinRequest'
+            examples:
+              request:
+                description: A checkin request from an elastic-agent.
+                value:
+                  status: online
+                  message: ""
+                  ack_token: previous-token
+      responses:
+        '200':
+          description: Agent checkin successful. May include actions.
+          headers:
+            Content-Encoding:
+              description: Responses may be compressed if the accept encoding indicates it. Currently not used by the agent.
+              schema:
+                type: string
+              examples:
+                gzip:
+                  description: Response is gzip encoded as the request headers allowed it.
+                  value: gzip
+
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/checkinResponse'
+              examples:
+                response:
+                  description: Agent successfully checked in.
+                  value:
+                    action: checkin
+                    ack_token: new-token
+                    actions:
+                      - agent_id: test-agent
+                        created_at: 2022-12-01T01:02:03Z
+                        data:
+                          log_level: debug
+                        id: test-action
+                        type: SETTINGS
+        '400':
+          $ref: '#/components/responses/badRequest'
+        '401':
+          $ref: '#/components/responses/keyNotEnabled'
+        '404':
+          $ref: '#/components/responses/agentNotFound'
+        '408':
+          $ref: '#/components/responses/deadline'
+        '503':
+          $ref: '#/components/responses/unavailable'
+  /api/fleet/agents/{id}/acks:
+    post:
+      description: |
+        The endpoint that an agent uses to acknowledge (and inform fleet-server) of events that it has recieved/executed.
+        A single action may have multiple different events associated with it.
+        Also an action may not have any acks associated with it.
+      parameters:
+        - name: id
+          in: path
+          description: The agent ID.
+          required: true
+          schema:
+            type: string
+        - $ref: '#/components/parameters/requestId'
+      security:
+        - agentApiKey: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ackRequest'
+            examples:
+              single:
+                description: Send an ack for a single event.
+                value:
+                  events:
+                    - type: ACTION_RESULT
+                      subtype: ACKNOWLEDGED
+                      agent_id: test-agent
+                      action_id: test-action
+                      timestamp: 2022-12-01T01:02:03.00004-07:00
+                      message: Action 'test-action' of type 'TEST' acknowledged.
+      responses:
+        '200':
+          description: Agent ack successfully received.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ackResponse'
+              examples:
+                single:
+                  description: Successfull ack for a single action.
+                  value:
+                    action: acks
+                    errors: false
+                    items:
+                      - status: 200
+                        message: ok
+        '400':
+          $ref: '#/components/responses/badRequest'
+        '401':
+          $ref: '#/components/responses/keyNotEnabled'
+        '404':
+          $ref: '#/components/responses/agentNotFound'
+        '408':
+          $ref: '#/components/responses/deadline'
+        '503':
+          $ref: '#/components/responses/unavailable'
+  /api/fleet/artifacts/{id}/{sha2}:
+    get:
+      description: The route to retrieve an artifact from Elasticsearch.
+      parameters:
+        - name: id
+          in: path
+          description: The artifact record ID.
+          required: true
+          schema:
+            type: string
+        - name: sha2
+          in: path
+          description: The decoded Sha256 associated with the artifact record.
+          required: true
+          schema:
+            type: string
+        - $ref: '#/components/parameters/requestId'
+      security:
+        - agentApiKey: []
+      responses:
+        '200':
+          description: The artifact retrieved from ES.
+          content:
+            application/octet-stream: # FIXME: Not sure if this is octet-stream, json (as it's encoded), or just text
+              schema:
+                type: string
+                format: base64
+        '400':
+          $ref: '#/components/responses/badRequest'
+        '401':
+          $ref: '#/components/responses/keyNotEnabled'
+        '404':
+          $ref: '#/components/responses/agentNotFound'
+        '408':
+          $ref: '#/components/responses/deadline'
+        '428':
+          $ref: '#/components/responses/throttle'
+        '503':
+          $ref: '#/components/responses/unavailable'
+# TODO: Include the file-upload endpoints?


### PR DESCRIPTION
Here's an openapi file that contains details on how the fleet-server and elastic-agent endpoint work.

I have a lot of `FIXME` comments throughout, mainly on attributes that we may want to deprecate or discuss further.